### PR TITLE
Load/unload `nvidia_uvm` module for latest propriatary drivers

### DIFF
--- a/nvidia/hooks/qemu.d/win10/prepare/begin/start.sh
+++ b/nvidia/hooks/qemu.d/win10/prepare/begin/start.sh
@@ -20,6 +20,7 @@ sleep 5
 
 # Unload all Nvidia drivers
 modprobe -r nvidia_drm
+modprobe -r nvidia_uvm
 modprobe -r nvidia_modeset
 modprobe -r drm_kms_helper
 modprobe -r nvidia

--- a/nvidia/hooks/qemu.d/win10/release/end/revert.sh
+++ b/nvidia/hooks/qemu.d/win10/release/end/revert.sh
@@ -24,6 +24,7 @@ echo "efi-framebuffer.0" > /sys/bus/platform/drivers/efi-framebuffer/bind
 
 #Load nvidia driver
 modprobe nvidia_drm
+modprobe nvidia_uvm
 modprobe nvidia_modeset
 modprobe drm_kms_helper
 modprobe nvidia


### PR DESCRIPTION
As for me with the latest drivers (495) unloading failed due to `nvidia_uvm` not being unloaded on Pop!OS 21.10 I'm suggesting to add it to the scripts