### PR TITLE
Fix for virsh issues and addition of hugepages

### DIFF
--- a/amd/hooks/qemu.d/win10/prepare/begin/start.sh
+++ b/amd/hooks/qemu.d/win10/prepare/begin/start.sh
@@ -21,10 +21,6 @@ sleep 5
 # Unload all AMD drivers
 modprobe -r amdgpu
 
-# Unbind the GPU from display driver
-virsh nodedev-detach $VIRSH_GPU_VIDEO
-virsh nodedev-detach $VIRSH_GPU_AUDIO
-
 # Load VFIO kernel module
 modprobe vfio
 modprobe vfio_pci

--- a/amd/hooks/qemu.d/win10/release/end/revert.sh
+++ b/amd/hooks/qemu.d/win10/release/end/revert.sh
@@ -9,11 +9,6 @@ modprobe -r vfio_pci
 modprobe -r vfio_iommu_type1
 modprobe -r vfio
 
-# Re-Bind GPU to AMD Driver
-virsh nodedev-reattach $VIRSH_GPU_VIDEO
-virsh nodedev-reattach $VIRSH_GPU_AUDIO
-
-
 # Rebind VT consoles
 echo 1 > /sys/class/vtconsole/vtcon0/bind
 echo 0 > /sys/class/vtconsole/vtcon1/bind

--- a/nvidia/hooks/qemu.d/win10/prepare/begin/start.sh
+++ b/nvidia/hooks/qemu.d/win10/prepare/begin/start.sh
@@ -27,10 +27,6 @@ modprobe -r nvidia
 modprobe -r i2c_nvidia_gpu
 modprobe -r drm
 
-# Unbind the GPU from display driver
-virsh nodedev-detach $VIRSH_GPU_VIDEO
-virsh nodedev-detach $VIRSH_GPU_AUDIO
-
 # Load VFIO kernel module
 modprobe vfio
 modprobe vfio_pci

--- a/nvidia/hooks/qemu.d/win10/release/end/revert.sh
+++ b/nvidia/hooks/qemu.d/win10/release/end/revert.sh
@@ -9,11 +9,6 @@ modprobe -r vfio_pci
 modprobe -r vfio_iommu_type1
 modprobe -r vfio
 
-# Re-Bind GPU to AMD Driver
-virsh nodedev-reattach $VIRSH_GPU_VIDEO
-virsh nodedev-reattach $VIRSH_GPU_AUDIO
-
-
 # Rebind VT consoles
 echo 1 > /sys/class/vtconsole/vtcon0/bind
 echo 0 > /sys/class/vtconsole/vtcon1/bind

--- a/optionalHooks/prepare/begin/alloc_hugepages.sh
+++ b/optionalHooks/prepare/begin/alloc_hugepages.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+# Credit to Maagu Karuri (@Karuri) on Gitlab
+# https://gitlab.com/Karuri/vfio
+#
+## Load the config file
+source "/etc/libvirt/hooks/kvm.conf"
+
+## Calculate number of hugepages to allocate from memory (in MB)
+HUGEPAGES="$(($MEMORY/$(($(grep Hugepagesize /proc/meminfo | awk '{print $2}')/1024))))"
+
+echo "Allocating hugepages..."
+echo $HUGEPAGES > /proc/sys/vm/nr_hugepages
+ALLOC_PAGES=$(cat /proc/sys/vm/nr_hugepages)
+
+TRIES=0
+while (( $ALLOC_PAGES != $HUGEPAGES && $TRIES < 1000 ))
+do
+    echo 1 > /proc/sys/vm/compact_memory            ## defrag ram
+    echo $HUGEPAGES > /proc/sys/vm/nr_hugepages
+    ALLOC_PAGES=$(cat /proc/sys/vm/nr_hugepages)
+    echo "Succesfully allocated $ALLOC_PAGES / $HUGEPAGES"
+    let TRIES+=1
+done
+
+if [ "$ALLOC_PAGES" -ne "$HUGEPAGES" ]
+then
+    echo "Not able to allocate all hugepages. Reverting..."
+    echo 0 > /proc/sys/vm/nr_hugepages
+    exit 1
+fi

--- a/optionalHooks/release/end/dealloc_hugepages.sh
+++ b/optionalHooks/release/end/dealloc_hugepages.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+#
+# Credit to Maagu Karuri (@Karuri) on Gitlab
+# https://gitlab.com/Karuri/vfio
+#
+## Load the config file
+source "/etc/libvirt/hooks/kvm.conf"
+
+echo 0 > /proc/sys/vm/nr_hugepages


### PR DESCRIPTION
This remove the virsh commands from the hooks fixing numerous issues as well as adding a system for automatically allocating and de-allocating hugepages. Hugepages may not be available for every system so you should create a function in the python script for checking by running the alloc_hugepages.sh to verify that it works and then running dealloc_hugepages.sh to free the ram back up. It will also need the hugepages function listed below in win10.xml as well as a memory value in MiB in kvm.conf matching that of the VM. The hugepages scripts are optional but highly recommend as they reduce stuttering.


<pre>
&lt;domain type='kvm'&gt;
...
  &lt;currentMemory unit='KiB'&gt;16777216&lt;/currentMemory&gt;
  <b>&lt;memoryBacking&gt;
    &lt;hugepages/&gt;
  &lt;/memoryBacking&gt;</b>
  &lt;vcpu placement='static'>8&lt;/vcpu&gt;
...
&lt;/domain&gt;
</pre>